### PR TITLE
Fixed RequiredProperties MIN_NUMERIC value to prevent error on user create screen.

### DIFF
--- a/react/src/sdk/helpers.js
+++ b/react/src/sdk/helpers.js
@@ -9,7 +9,7 @@ export const RequiredProperties = {
   MIN_CHARACTERS: 'minCharacters',
   MIN_LOWERCASE: 'abcdefghijklmnopqrstuvwxyz',
   MIN_UPPERCASE: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
-  MIN_NUMERIC: '1234567890',
+  MIN_NUMERIC: '0123456789',
   MIN_SPECIAL: '~!@#$%^&*()-_=+[]{}|;:,.<>/?',
   MIN_COMPLEXITY: 'minComplexity',
 };


### PR DESCRIPTION
Changes the lookup value of `RequiredProperties.MIN_NUMERIC` from `'1234567890'` to `'0123456789'` to prevent a parsing error that breaks the create account page with error `TypeError: Cannot read property 'min' of undefined`.